### PR TITLE
List Firefox as supported without polyfills

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         <em>&lt;css-doodle /&gt; </em> is based on
         <a href="http://w3c.github.io/webcomponents/spec/shadow/">Shadow DOM v1</a> and
         <a href="https://html.spec.whatwg.org/multipage/scripting.html#custom-elements">Custom Elements v1</a>.
-        You can use it on latest <em>Chrome</em> and <em>Safari</em> right now without polyfills.
+        You can use it on latest <em>Chrome</em>, <em>Safari</em> and <em>Firefox</em> right now without polyfills.
       </p>
       <p>
         The component will generate a grid of divs by the rules (plain CSS) inside it.


### PR DESCRIPTION
To be merged on 2018-10-23 when Firefox 63 ships.

References:
https://caniuse.com/#search=web%20components
https://wiki.mozilla.org/Release_Management/Calendar

Tested as working right now in Nightly (64).