### PR TITLE
 fix: The spelling of the word 'definition'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1780,7 +1780,7 @@
           <h4><a name="function-@var"></a><span>@var(expr)</span></h4>
           <p>
             Same as native <code>var()</code>. Used to prevent the browser from evaluating the value inside nested vars.
-            The example below won't work since the <code>var(--bg)</code> has no defnition outside.
+            The example below won't work since the <code>var(--bg)</code> has no definition outside.
           </p>
           <p>
             <textarea code>


### PR DESCRIPTION
update “defnition” to “definition”